### PR TITLE
Update kbricks_core.scad

### DIFF
--- a/scad/kbricks_core.scad
+++ b/scad/kbricks_core.scad
@@ -412,7 +412,7 @@ module figure_hand() {
     r2 = axle_diameter/2 + axle_tolerance/2;
     difference() {
         union() {
-            rotate([180, 0, 0])
+            rotate([180, 0, 90])
             peg_half();
             translate([0, 0, cube_size/4])
             rotate([90, 0, 0])


### PR DESCRIPTION
Rotate the slot in the peg so it is inline with the slot in the hand.
This makes printing the hand flat more easy.
For strength I print them flat with support only touching the buildplate.